### PR TITLE
bug fix

### DIFF
--- a/src/v12/Util.js
+++ b/src/v12/Util.js
@@ -95,10 +95,10 @@ module.exports = {
   resolveType(type) {
     return typeof type === 'string' ? MessageComponentTypes[type] : type;
   },
-  resolveMaxValues(m1, m2) {
+  resolveMaxValues(m1, m2 = 0) {
     return m1 || m2;
   },
-  resolveMinValues(m1, m2) {
+  resolveMinValues(m1, m2 = 0) {
     return m1 || m2;
   },
   isEmoji(string) {


### PR DESCRIPTION
I was unable to specify a Minimum value of 0 because `resolveMinValues` was being called by `MessageMenu.setMinValues` as `resolveMinValues(number)` while this function uses 2 values. This means the second value was `undefined`, and `0 || undefined` will return `undefined`, which is incorrect since Discord's default is 1.

I'm not sure if this should be the final code, I just wanted to make something quick so I can finish my project.