### PR TITLE
fix(MessageMenu & MessageMenuOption): Add support for `.setDisabled` and improve `.setDefault`

### DIFF
--- a/src/v12/Classes/MessageMenu.js
+++ b/src/v12/Classes/MessageMenu.js
@@ -72,7 +72,7 @@ class MessageMenu extends BaseMessageComponent {
     return this;
   }
   
-  setDisabled(disable = true) {
+  setDisabled(disable = false) {
     this.disabled = typeof disable === 'boolean' ? disable : false;
     return this;
   }

--- a/src/v12/Classes/MessageMenu.js
+++ b/src/v12/Classes/MessageMenu.js
@@ -72,8 +72,8 @@ class MessageMenu extends BaseMessageComponent {
     return this;
   }
   
-  setDisabled(disable = false) {
-    this.disabled = typeof disable === 'boolean' ? disable : false;
+  setDisabled(disable = true) {
+    this.disabled = typeof disable === 'boolean' ? disable : true;
     return this;
   }
 

--- a/src/v12/Classes/MessageMenu.js
+++ b/src/v12/Classes/MessageMenu.js
@@ -16,6 +16,8 @@ class MessageMenu extends BaseMessageComponent {
 
     this.min_values = ('minValues' in data) | ('min_values' in data) ? resolveMinValues(data.minValues, data.min_values) : undefined;
 
+    this.disabled = (('disabled' in data) && (typeof data.disabled === 'boolean')) ? data.disabled : false;
+
     this.options = [];
     if ('option' in data) {
       data.option.type = 'SELECT_MENU_OPTION';
@@ -69,6 +71,11 @@ class MessageMenu extends BaseMessageComponent {
     this.components.splice(index, deleteCount, ...options.flat(Infinity).map((c) => new MessageMenuOption(c).toJSON()));
     return this;
   }
+  
+  setDisabled(disable = true) {
+    this.disabled = typeof disable === 'boolean' ? disable : false;
+    return this;
+  }
 
   toJSON() {
     return {
@@ -78,6 +85,7 @@ class MessageMenu extends BaseMessageComponent {
       max_values: this.max_values,
       min_values: this.min_values,
       options: this.options,
+      disabled: this.disabled
     };
   }
 }

--- a/src/v12/Util.js
+++ b/src/v12/Util.js
@@ -64,13 +64,16 @@ module.exports = {
     let maxValues = this.resolveMaxValues(data.max_values);
     let minValues = this.resolveMinValues(data.min_values);
 
+    let disabled = typeof data.disabled === 'boolean' ? data.disabled : false;
+
     return {
       type: MessageComponentTypes.SELECT_MENU,
-      placeholder: data.placeholder,
       custom_id: data.custom_id,
       options: options,
-      max_values: maxValues,
+      placeholder: data.placeholder,
       min_values: minValues,
+      max_values: maxValues,
+      disabled: disabled
     };
   },
   resolveMenuOptions(data) {
@@ -85,8 +88,9 @@ module.exports = {
       options.push({
         label: d.label,
         value: d.value,
-        emoji: d.emoji,
         description: d.description,
+        emoji: d.emoji,
+        default: d.default
       });
     });
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,9 +133,10 @@ export interface MessageButtonOptions {
 export interface MessageMenuOptions {
   type: MessageComponentTypes.SELECT_MENU;
   label?: string;
-  emoji?: string | GuildButtonEmoji;
-  description?: string;
   value?: string;
+  description?: string;
+  emoji?: string | GuildButtonEmoji;
+  default?: boolean;
 }
 
 export interface MessageButtonData {
@@ -155,18 +156,20 @@ export interface MessageActionRowData {
 
 export interface MessageMenuData {
   type?: MessageComponentTypes.SELECT_MENU;
-  placeholder?: string;
   custom_id?: string;
-  max_values?: number;
-  min_values?: number;
   options?: Array<MessageMenuOptions>;
+  placeholder?: string;
+  min_values?: number;
+  max_values?: number;
+  disabled?: boolean;
 }
 
 export interface MessageMenuOptionsData {
   label?: string;
-  emoji?: string | GuildButtonEmoji;
-  description?: string;
   value?: string;
+  description?: string;
+  emoji?: string | GuildButtonEmoji;
+  default?: boolean;
 }
 
 export class InteractionReply {
@@ -273,6 +276,7 @@ export class MessageMenu extends BaseMessageComponent {
   public addOption(option: MessageMenuOption): MessageMenu;
   public addOptions(...options: MessageMenuOption[]): MessageMenu;
   public removeOptions(index: number, deleteCount: number, ...options: MessageMenuOption[]): MessageMenu;
+  public setDisabled(disable?: boolean): MessageMenu;
   public toJSON(): MessageMenuData;
 }
 


### PR DESCRIPTION
Pull requests #138 and #139 did not properly implement these methods, as they forget to update the src/v12/Util.js file, resolveMenu and resolveMenuOptions methods, to be more precise, and, If I'm not mistaken, some typings aswell, causing unwanted behaviours in the code.