### PR TITLE
fix: boolean instanceof, MessageActionRow, Util(resolveStyle)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ module.exports.multipleImport = (...clients) => {
   }
 
   clients.forEach((client) => {
-    if (!client || !client instanceof Client) throw new Error("INVALID_CLIENT_PROVIDED: Your discord.js Client is invalid or has not been provided.");
+    if (!(client instanceof Client)) throw new Error("INVALID_CLIENT_PROVIDED: Your discord.js Client is invalid or has not been provided.");
 
     client.ws.on('INTERACTION_CREATE', (data) => {
       if (!data.data.component_type) return;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = (client) => {
     throw new Error('Your discord.js version must be v12 or higher.');
   }
 
-  if (!client || !(client instanceof Client)) throw new Error("INVALID_CLIENT_PROVIDED: Your discord.js Client is invalid or has not been provided.");
+  if (!(client instanceof Client)) throw new Error("INVALID_CLIENT_PROVIDED: Your discord.js Client is invalid or has not been provided.");
 
   const message = Structures.get('Message');
   if (!message.createButtonCollector || typeof message.createButtonCollector !== 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = (client) => {
     throw new Error('Your discord.js version must be v12 or higher.');
   }
 
-  if (!client || !client instanceof Client) throw new Error("INVALID_CLIENT_PROVIDED: Your discord.js Client is invalid or has not been provided.");
+  if (!client || !(client instanceof Client)) throw new Error("INVALID_CLIENT_PROVIDED: Your discord.js Client is invalid or has not been provided.");
 
   const message = Structures.get('Message');
   if (!message.createButtonCollector || typeof message.createButtonCollector !== 'function') {

--- a/src/v12/Classes/MessageActionRow.js
+++ b/src/v12/Classes/MessageActionRow.js
@@ -52,7 +52,7 @@ class MessageActionRow extends BaseMessageComponent {
             }
           })
         : [],
-      type: MessageComponentTypes[this.type],
+      type: MessageComponentTypes.ACTION_ROW,
     };
   }
 }

--- a/src/v12/Util.js
+++ b/src/v12/Util.js
@@ -2,17 +2,11 @@ const { MessageButtonStyles, MessageButtonStylesAliases, MessageComponentTypes }
 
 module.exports = {
   resolveStyle(style) {
-    if (!style || style === undefined || style === null) throw new TypeError('NO_BUTTON_STYLE: Please provide a button style.');
+    if (!style) throw new TypeError('NO_BUTTON_STYLE: Please provide a button style.');
 
-    if (style === 'gray') style = 'grey';
+    if((!MessageButtonStyles[style]) && (!MessageButtonStylesAliases[style])) throw new TypeError('INVALID_BUTTON_STYLE: An invalid button style was provided.');
 
-    if (
-      (!MessageButtonStyles[style] || MessageButtonStyles[style] === undefined || MessageButtonStyles[style] === null) &&
-      (!MessageButtonStylesAliases[style] || MessageButtonStylesAliases[style] === undefined || MessageButtonStylesAliases[style] === null)
-    )
-      throw new TypeError('INVALID_BUTTON_STYLE: An invalid button style was provided.');
-
-    return typeof style === 'string' ? MessageButtonStyles[style] : style;
+    return MessageButtonStyles[style] ? MessageButtonStyles[style] : MessageButtonStylesAliases[style];
   },
   resolveButton(data) {
     if (data.type !== MessageComponentTypes.BUTTON) throw new TypeError('INVALID_BUTTON_TYPE: Invalid type.');


### PR DESCRIPTION
**Why?** (boolean instanceof)
When you have `if(!client || !client instanceOf Client)` it's completely useless. You have a client defined so don't bake it next. If there was a `&&` then again it wouldn't work because you have a defined client. So `if(!(client instanceOf Client))` does that if the client is not a djs client so it won't go. If the client is not defined it won't go either, because the client is not a djs client.

**Why?** (MessageActionRow)
It was probably just a typo but very important. Because of this, I couldn't simply send a slash command with components without InteractionReply.

**Why?** (Util(resolveStyle))
Previously the code was completely useless and didn't even work properly. You couldn't use aliases.